### PR TITLE
Update Query.js

### DIFF
--- a/lib/Query.js
+++ b/lib/Query.js
@@ -202,6 +202,7 @@ Query.prototype.exec = function (next) {
       function toModel (item) {
         var model = new Model();
         model.$__.isNew = false;
+        item = JSON.stringify(item);
         schema.parseDynamo(model, item);
 
         debug('query parsed model', model);


### PR DESCRIPTION
there is an error without this line in some cases:
SyntaxError: Unexpected token o
    at parse (native)
    at dedynamofy (/opt/icid/registration/node_modules/dynamoose/lib/Attribute.js:404:14)
    at Attribute.parseDynamo (/opt/icid/registration/node_modules/dynamoose/lib/Attribute.js:467:13)
    at Schema.parseDynamo (/opt/icid/registration/node_modules/dynamoose/lib/Schema.js:80:45)
    at toModel (/opt/icid/registration/node_modules/dynamoose/lib/Query.js:206:16)
    at Array.map (native)
    at Response.<anonymous> (/opt/icid/registration/node_modules/dynamoose/lib/Query.js:214:31)
    at Request.<anonymous> (/opt/icid/registration/node_modules/aws-sdk/lib/request.js:353:18)
    at Request.callListeners (/opt/icid/registration/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/opt/icid/registration/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
